### PR TITLE
Add /health endpoint with temperature schedule check

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     implementation(mn.micronaut.jackson.databind)
     implementation(mn.micronaut.kotlin.runtime)
     implementation(mn.micronaut.validation)
+    implementation("io.micronaut:micronaut-management")
     implementation("jakarta.annotation:jakarta.annotation-api")
     implementation("org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion}")
     implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.7.1-0.6.x-compat")

--- a/src/main/kotlin/com/eddgrant/influxdbWeatherIngestor/checks/RegisterChecksAction.kt
+++ b/src/main/kotlin/com/eddgrant/influxdbWeatherIngestor/checks/RegisterChecksAction.kt
@@ -12,14 +12,20 @@ class RegisterChecksAction(
     private val temperatureEmitter: TemperatureEmitter,
     @field:Named(TaskExecutors.SCHEDULED) private val taskScheduler: TaskScheduler
 ) {
+    private var scheduledFuture: java.util.concurrent.ScheduledFuture<*>? = null
+
     fun register() {
         val checkTemperatureTask = CheckTemperatureTask(temperatureEmitter)
-        taskScheduler.schedule(
+        scheduledFuture = taskScheduler.schedule(
             checkConfiguration.scheduleExpression,
             checkTemperatureTask
         )
         LOGGER.info("Temperature checks scheduled to run on schedule: ${checkConfiguration.scheduleExpression}")
     }
+
+    fun isScheduleActive(): Boolean =
+        scheduledFuture != null && !scheduledFuture!!.isCancelled
+
  companion object {
      private val LOGGER = LoggerFactory.getLogger(RegisterChecksAction::class.java)
  }

--- a/src/main/kotlin/com/eddgrant/influxdbWeatherIngestor/checks/TemperatureScheduleHealthIndicator.kt
+++ b/src/main/kotlin/com/eddgrant/influxdbWeatherIngestor/checks/TemperatureScheduleHealthIndicator.kt
@@ -1,0 +1,25 @@
+package com.eddgrant.influxdbWeatherIngestor.checks
+
+import io.micronaut.core.async.publisher.Publishers
+import io.micronaut.health.HealthStatus
+import io.micronaut.management.health.indicator.HealthIndicator
+import io.micronaut.management.health.indicator.HealthResult
+import jakarta.inject.Singleton
+import org.reactivestreams.Publisher
+
+@Singleton
+class TemperatureScheduleHealthIndicator(
+    private val registerChecksAction: RegisterChecksAction
+) : HealthIndicator {
+
+    override fun getResult(): Publisher<HealthResult> {
+        val active = registerChecksAction.isScheduleActive()
+        val status = if (active) HealthStatus.UP else HealthStatus.DOWN
+        val details = mapOf("scheduleActive" to active)
+        return Publishers.just(
+            HealthResult.builder("temperatureSchedule", status)
+                .details(details)
+                .build()
+        )
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,5 +32,10 @@ logger:
     com:
       eddgrant: INFO
 
+endpoints:
+  health:
+    enabled: true
+    sensitive: false
+
 weather:
   provider: weatherapi.com

--- a/src/test/kotlin/com/eddgrant/influxdbWeatherIngestor/checks/TemperatureScheduleHealthIndicatorSpec.kt
+++ b/src/test/kotlin/com/eddgrant/influxdbWeatherIngestor/checks/TemperatureScheduleHealthIndicatorSpec.kt
@@ -1,0 +1,52 @@
+package com.eddgrant.influxdbWeatherIngestor.checks
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.micronaut.health.HealthStatus
+import io.micronaut.management.health.indicator.HealthResult
+import io.mockk.every
+import io.mockk.mockk
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
+import java.util.concurrent.CompletableFuture
+
+private fun Publisher<HealthResult>.blockFirst(): HealthResult {
+    val future = CompletableFuture<HealthResult>()
+    subscribe(object : Subscriber<HealthResult> {
+        override fun onSubscribe(s: Subscription) = s.request(1)
+        override fun onNext(t: HealthResult) = future.complete(t).let {}
+        override fun onError(t: Throwable) = future.completeExceptionally(t).let {}
+        override fun onComplete() {}
+    })
+    return future.get()
+}
+
+class TemperatureScheduleHealthIndicatorSpec : StringSpec({
+
+    "it reports UP when the schedule is active" {
+        val registerChecksAction = mockk<RegisterChecksAction>()
+        every { registerChecksAction.isScheduleActive() } returns true
+
+        val indicator = TemperatureScheduleHealthIndicator(registerChecksAction)
+        val result = indicator.result.blockFirst()
+
+        result.status shouldBe HealthStatus.UP
+        @Suppress("UNCHECKED_CAST")
+        val details = result.details as Map<String, Any>
+        details["scheduleActive"] shouldBe true
+    }
+
+    "it reports DOWN when the schedule is not active" {
+        val registerChecksAction = mockk<RegisterChecksAction>()
+        every { registerChecksAction.isScheduleActive() } returns false
+
+        val indicator = TemperatureScheduleHealthIndicator(registerChecksAction)
+        val result = indicator.result.blockFirst()
+
+        result.status shouldBe HealthStatus.DOWN
+        @Suppress("UNCHECKED_CAST")
+        val details = result.details as Map<String, Any>
+        details["scheduleActive"] shouldBe false
+    }
+})


### PR DESCRIPTION
## Summary
- Add `micronaut-management` dependency for health endpoint support
- Enable `/health` endpoint (non-sensitive) in `application.yml`
- Track the `ScheduledFuture` in `RegisterChecksAction` and expose `isScheduleActive()`
- Add `TemperatureScheduleHealthIndicator` — reports `UP` when the temperature check cron schedule is active, `DOWN` if cancelled or not registered
- Add unit tests for both health states

When running, `GET /health` returns:
```json
{
  "status": "UP",
  "details": {
    "temperatureSchedule": {
      "status": "UP",
      "details": { "scheduleActive": true }
    }
  }
}
```

## Test plan
- [x] Unit tests pass (UP and DOWN scenarios)
- [ ] Verify `/health` returns meaningful response when running in Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)